### PR TITLE
Changes for VS 2017 compiler support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required (VERSION 3.1)
 project(cbor11)
 set(CMAKE_CXX_STANDARD 11)
+
+IF(WIN32)
+  if(MSVC)
+     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+  endif()
+ENDIF()
+
 add_library(cbor11 src/cbor11.cpp)
 target_include_directories(cbor11 PRIVATE include)
 

--- a/tst/cbor11_tests.cpp
+++ b/tst/cbor11_tests.cpp
@@ -50,6 +50,10 @@ bool test_serialization_deserialization()
         }
     }
 
+    using nld = std::numeric_limits<double>;
+    static_assert(nld::has_quiet_NaN, "Quiet NaN is not avaialble.");
+    static_assert(nld::infinity, "Infinity is not avaialble.");
+
     const cbor item = cbor::array {
             cbor::array {24, 23, 12, -12, -24, -25},
             "Hello",
@@ -70,9 +74,8 @@ bool test_serialization_deserialization()
             cbor::undefined,
             cbor::tagged(1024, -1.5),
             1000000000000000,
-            1/0.,
-            -1/0.,
-            0/0.,
+            nld::infinity(),
+            nld::quiet_NaN(),
             1.2,
             1.2f
     };


### PR DESCRIPTION
VS2017 did not like 1/0. for inifinity, nor 0/0. for NaN
I could not find a substitute/constant for -1/0. (-infinity)